### PR TITLE
Work around multiple measurement error by only measuring every 100 te…

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -43,6 +43,7 @@ library
 
   exposed-modules:
       Test.Example.Basic
+    , Test.Example.Confidence
     , Test.Example.Coverage
     , Test.Example.Exception
     , Test.Example.List

--- a/hedgehog-example/src/Test/Example/Confidence.hs
+++ b/hedgehog-example/src/Test/Example/Confidence.hs
@@ -16,7 +16,7 @@ import qualified Hedgehog.Internal.Gen as Gen
 prop_without_confidence :: Property
 prop_without_confidence =
   withConfidence (10^9) . withTests 1000000 . property $ do
-    number <- forAll (Gen.int $ Range.linear 1 10)
+    number <- forAll (Gen.int $ Range.constant 1 2)
     cover 60 "number == 1" $ number == 1
 
 ------------------------------------------------------------------------

--- a/hedgehog-example/test/test.hs
+++ b/hedgehog-example/test/test.hs
@@ -1,14 +1,15 @@
 import           System.IO (BufferMode(..), hSetBuffering, stdout, stderr)
 
-import qualified Test.Example.Basic as Test.Example.Basic
-import qualified Test.Example.Coverage as Test.Example.Coverage
-import qualified Test.Example.Exception as Test.Example.Exception
-import qualified Test.Example.QuickCheck as Test.Example.QuickCheck
-import qualified Test.Example.References as Test.Example.References
-import qualified Test.Example.Registry as Test.Example.Registry
-import qualified Test.Example.Resource as Test.Example.Resource
-import qualified Test.Example.Roundtrip as Test.Example.Roundtrip
-import qualified Test.Example.STLC as Test.Example.STLC
+import qualified Test.Example.Basic
+import qualified Test.Example.Confidence
+import qualified Test.Example.Coverage
+import qualified Test.Example.Exception
+import qualified Test.Example.QuickCheck
+import qualified Test.Example.References
+import qualified Test.Example.Registry
+import qualified Test.Example.Resource
+import qualified Test.Example.Roundtrip
+import qualified Test.Example.STLC
 
 main :: IO ()
 main = do
@@ -17,6 +18,7 @@ main = do
 
   _results <- sequence [
       Test.Example.Basic.tests
+    , Test.Example.Confidence.tests
     , Test.Example.Coverage.tests
     , Test.Example.Exception.tests
     , Test.Example.QuickCheck.tests

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -113,6 +113,8 @@ module Hedgehog.Internal.Property (
   , mkTestT
   , runTest
   , runTestT
+
+  , wilsonBounds
   ) where
 
 import           Control.Applicative (Alternative(..))
@@ -425,7 +427,7 @@ newtype CoverCount =
 newtype CoverPercentage =
   CoverPercentage {
       unCoverPercentage :: Double
-    } deriving (Eq, Ord, Show, Num)
+    } deriving (Eq, Ord, Show, Num, Fractional)
 
 -- | The name of a classifier.
 --
@@ -1067,12 +1069,10 @@ confidenceSuccess tests confidence =
   let
     -- FIXME this tolerance could be customizable in `Confidence`, barring
     -- making the API less intuitive
-    tolerance = 0.9
     assertLow :: Label CoverCount -> Bool
     assertLow coverCount@MkLabel{..} =
       fst (boundsForLabel tests confidence coverCount)
-      >=
-      tolerance * (unCoverPercentage labelMinimum / 100.0)
+        >= unCoverPercentage labelMinimum / 100.0
   in
     and . fmap assertLow . Map.elems . coverageLabels
 
@@ -1084,8 +1084,7 @@ confidenceFailure tests confidence =
     assertHigh :: Label CoverCount -> Bool
     assertHigh coverCount@MkLabel{..} =
       snd (boundsForLabel tests confidence coverCount)
-      <
-      (unCoverPercentage labelMinimum / 100.0)
+        < (unCoverPercentage labelMinimum / 100.0)
   in
     or . fmap assertHigh . Map.elems . coverageLabels
 

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -167,16 +167,18 @@ checkReport cfg size0 seed0 test0 updateUI =
       propertyConfidence cfg
 
     successVerified count coverage =
-      count > 0 &&
+      count `mod` 100 == 0 &&
       -- If the user wants a statistically significant result, this function
       -- will run a confidence check. Otherwise, it will default to checking
       -- the percentage of encountered labels
       maybe False (\c -> confidenceSuccess count c coverage) confidence
 
     failureVerified count coverage =
-      count > 0 &&
       -- Will be true if we can statistically verify that our coverage was
-      -- inadequate
+      -- inadequate.
+      -- Testing only on 100s to minimise repeated measurement statistical
+      -- errors.
+      count `mod` 100 == 0 &&
       maybe False (\c -> confidenceFailure count c coverage) confidence
 
     loop ::
@@ -198,7 +200,7 @@ checkReport cfg size0 seed0 test0 updateUI =
           successVerified tests coverage0
         enoughTestsRun =
           tests >= fromIntegral (fromMaybe defaultMinTests testLimit) &&
-          (isNothing (propertyConfidence cfg) || hasReachedCoverage)
+            (isNothing (propertyConfidence cfg) || hasReachedCoverage)
 
       if size > 99 then
         -- size has reached limit, reset to 0
@@ -217,7 +219,7 @@ checkReport cfg size0 seed0 test0 updateUI =
             0
             (Just coverage0)
             Nothing
-            "Test coverage cannot be reached, aborted"
+            ("Test coverage cannot be reached after " <> show tests <> " tests")
             Nothing
             []
 


### PR DESCRIPTION
…sts.

This isn't technically correct, but it's quite a lot better than
not doing it.